### PR TITLE
Dzelge xxx fix env

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## v1.0.3 (in development)
+## v1.0.3
 
 ### New Features
 
@@ -6,6 +6,8 @@
   for e.g. testing purposes.
 - A new geoDB docker backend image has been added. This image can be used to set up a postgis database with a 
   pre-installed geodb database extension 
+- Added a new `count_by_bbox` filter function 
+
 
 ### Fixes
 

--- a/xcube_geodb/core/geodb.py
+++ b/xcube_geodb/core/geodb.py
@@ -1431,6 +1431,80 @@ class GeoDBClient(object):
         except GeoDBError as e:
             return self._maybe_raise(e, return_df=True)
 
+    def count_collection_by_bbox(self, collection: str,
+                                 bbox: Tuple[float, float, float, float],
+                                 comparison_mode: str = 'contains',
+                                 bbox_crs: Union[int, str] = 4326,
+                                 where: Optional[str] = "id>-1",
+                                 op: str = 'AND',
+                                 database: Optional[str] = None,
+                                 wsg84_order="lat_lon") -> Union[GeoDataFrame, DataFrame]:
+        """
+        Query the database by a bounding box and return the count. Please be careful with the bbox crs. The easiest is
+        using the same crs as the collection. However, if the bbox crs differs from the collection,
+        the geoDB client will attempt to automatially transform the bbox crs according to the collection's crs.
+        You can also directly use the method GeoDBClient.transform_bbox_crs yourself before you pass the bbox into
+        this method.
+
+        Args:
+            collection (str): The name of the collection to be quried
+            bbox (Tuple[float, float, float, float]): minx, miny, maxx, maxy
+            comparison_mode (str): Filter mode. Can be 'contains' or 'within' ['contains']
+            bbox_crs (int, str): Projection code. [4326]
+            op (str): Operator for where (AND, OR) ['AND']
+            where (str): Additional SQL where statement to further filter the collection
+            database (str): The name of the database the collection resides in [current database]
+            wsg84_order (str): WSG84 (EPSG:4326) is expected to be in Lat Lon format ("lat_lon"). Use "lon_lat" if
+            Lon Lat is used.
+
+        Returns:
+            A GeoPandas Dataframe
+
+        Raises:
+            HttpError: When the database raises an error
+
+        Examples:
+            >>> geodb = GeoDBClient()
+            >>> geodb.count_collection_by_bbox(table="[MyCollection]", bbox=(452750.0, 88909.549, 464000.0, \
+                102486.299), comparison_mode="contains", bbox_crs=3794)
+        """
+        bbox_crs = check_crs(bbox_crs)
+        database = database or self.database
+        dn = database + '_' + collection
+
+        self._raise_for_collection_exists(collection=collection, database=database)
+        self._raise_for_stored_procedure_exists('geodb_get_by_bbox')
+
+        coll_crs = self.get_collection_srid(collection=collection, database=database)
+
+        try:
+            if coll_crs is not None and coll_crs != bbox_crs:
+                bbox = self.transform_bbox_crs(bbox, bbox_crs, int(coll_crs), wsg84_order=wsg84_order)
+                bbox_crs = coll_crs
+            print(bbox)
+            headers = {'Accept': 'application/vnd.pgrst.object+json'}
+
+            r = self._post('/rpc/geodb_count_by_bbox', headers=headers, payload={
+                "collection": dn,
+                "minx": bbox[0],
+                "miny": bbox[1],
+                "maxx": bbox[2],
+                "maxy": bbox[3],
+                "comparison_mode": comparison_mode,
+                "bbox_crs": bbox_crs,
+                "where": where,
+                "op": op
+            })
+
+            js = r.json()['src']
+            if js:
+                srid = self.get_collection_srid(collection, database)
+                return self._df_from_json(js, srid)
+            else:
+                return GeoDataFrame(columns=["Empty Result"])
+        except GeoDBError as e:
+            return self._maybe_raise(e, return_df=True)
+
     def head_collection(self, collection: str, num_lines: int = 10, database: Optional[str] = None) -> \
             Union[GeoDataFrame, DataFrame]:
         """

--- a/xcube_geodb/sql/geodb.sql
+++ b/xcube_geodb/sql/geodb.sql
@@ -1030,6 +1030,7 @@ END
 $BODY$;
 
 
+-- TODO Merge with get_by_bbox
 CREATE OR REPLACE FUNCTION public.geodb_count_by_bbox(collection text,
                                                       minx double precision,
                                                       miny double precision,

--- a/xcube_geodb/sql/geodb.sql
+++ b/xcube_geodb/sql/geodb.sql
@@ -1010,12 +1010,88 @@ BEGIN
                       || ', ' || minx
                       || ' ' || miny
                       || '))'', geometry) '
-                      || 'ORDER BY id '
+                      || ' ORDER BY id '
                       || lmt_str || ') as src',
-                  collection,
-                  "where", op,
-                  bbox_func,
-                  bbox_crs
+                  "collection",
+                  "where",
+                  "op",
+                  "bbox_func",
+                  "bbox_crs"
+        );
+
+    RETURN QUERY EXECUTE qry;
+
+    GET DIAGNOSTICS row_ct = ROW_COUNT;
+
+    IF row_ct < 1 THEN
+        RAISE EXCEPTION 'Only % rows!', row_ct;
+    END IF;
+END
+$BODY$;
+
+
+CREATE OR REPLACE FUNCTION public.geodb_count_by_bbox(collection text,
+                                                      minx double precision,
+                                                      miny double precision,
+                                                      maxx double precision,
+                                                      maxy double precision,
+                                                      comparison_mode VARCHAR(255) DEFAULT 'within',
+                                                      bbox_crs int DEFAULT 4326,
+                                                      "where" text DEFAULT 'id > 0'::text,
+                                                      op text DEFAULT 'AND'::text)
+    RETURNS TABLE
+            (
+                src json
+            )
+    LANGUAGE 'plpgsql'
+
+AS
+$BODY$
+DECLARE
+    bbox_func VARCHAR;
+    row_ct    int;
+    qry       text;
+BEGIN
+    CASE comparison_mode
+        WHEN 'within' THEN
+            bbox_func := 'ST_Within';
+        WHEN 'contains' THEN
+            bbox_func := 'ST_Contains';
+        WHEN 'intersects' THEN
+            bbox_func := 'ST_Intersects';
+        WHEN 'touches' THEN
+            bbox_func := 'ST_Touches';
+        WHEN 'overlaps' THEN
+            bbox_func := 'ST_Overlaps';
+        WHEN 'crosses' THEN
+            bbox_func := 'ST_Crosses';
+        WHEN 'disjoint' THEN
+            bbox_func := 'ST_Disjoint';
+        WHEN 'equals' THEN
+            bbox_func := 'ST_Equals';
+        ELSE RAISE EXCEPTION 'comparison mode % does not exist. Use ''within'' | ''contains''', comparison_mode USING ERRCODE = 'data_exception';
+        END CASE;
+
+    qry := format('SELECT JSON_AGG(src) as js
+                     FROM (SELECT COUNT(*) as ct FROM %I
+                     WHERE (%s) %s %s(''SRID=%s;POLYGON((' ||
+                  minx
+                      || ' ' || miny
+                      || ', ' || maxx
+                      || ' ' || miny
+                      || ', ' || maxx
+                      || ' ' || maxy
+                      || ', ' || minx
+                      || ' ' || maxy
+                      || ', ' || minx
+                      || ' ' || miny
+                      || '))'', geometry) '
+                      || ') as src',
+                  "collection",
+                  "where",
+                  "op",
+                  "bbox_func",
+                  "bbox_crs"
         );
 
     RETURN QUERY EXECUTE qry;

--- a/xcube_geodb/version.py
+++ b/xcube_geodb/version.py
@@ -1,1 +1,1 @@
-version = '1.0.3.dev0'
+version = '1.0.3'


### PR DESCRIPTION
When accepting this PR the following will be changed

### New Features

- Added a new auth mode `none`. The aim of this mode is enabling users installing the geoDB infrastructure without oauth2
  for e.g. testing purposes.
- A new geoDB docker backend image has been added. This image can be used to set up a postgis database with a 
  pre-installed geodb database extension 
- Added a new `count_by_bbox` filter function 


### Fixes

- Added Python pip requirements to have control over installed sphinx version on readthedocs
- Improved heading in notebooks
- Removed auto cp of notebooks in Makefile.
- Ensured that the geoDB client works with Keycloak
