### PR TITLE
Add function 'get_collection_bbox'

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -21,7 +21,7 @@ env:
   RUN_NB_TESTS: "1"
 
   # Determines whether the dev branch ouy are working on shall have a docker image (default 0)
-  DOCKER_BUILD_MY_BRANCH: "0"
+  DOCKER_BUILD_MY_BRANCH: "1"
 
 jobs:
   unittest:
@@ -132,7 +132,7 @@ jobs:
         id: info
         run: |
           echo "TAG: ${{ steps.release.outputs.tag }}"
-          echo "DEPLOYMENT_PASE: {{ steps.deployment-phase.outputs.phase }}"
+          echo "DEPLOYMENT_PHASE: ${{ steps.deployment-phase.outputs.phase }}"
           echo "REAL_VERSION: ${{ steps.real-version.outputs.version }}"
           echo "EVENT: ${{ github.event_name }}"
       # Build jupyter lab docker image

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,5 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+local_notebooks

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
 - A new geoDB docker backend image has been added. This image can be used to set up a postgis database with a 
   pre-installed geodb database extension 
 - Added a new `count_by_bbox` filter function 
+- Added the new function `get_collection_bbox`, that returns the bounding box
+  of all geometries within a collection.
 
 
 ### Fixes

--- a/tests/core/test_geodb.py
+++ b/tests/core/test_geodb.py
@@ -183,13 +183,13 @@ class GeoDBClientTest(unittest.TestCase):
 
     def test_get_collection_bbox(self, m):
         self.set_global_mocks(m)
-        expected_bbox = 'POLYGON ((9 51, 9 53, 11 53, 11 51, 9 51))'
+        expected_bbox = json.dumps([{'geodb_get_collection_bbox': 'BOX(-6 9,5 11)'}])
         url = f"{self._server_test_url}:" \
               f"{self._server_test_port}/rpc/geodb_get_collection_bbox"
         m.post(url, text=expected_bbox)
 
         r = self._api.get_collection_bbox('any')
-        self.assertEqual(expected_bbox, r)
+        self.assertEqual((9, -6, 11, 5), r)
 
     def test_rename_collection(self, m):
         self.set_global_mocks(m)

--- a/tests/core/test_geodb.py
+++ b/tests/core/test_geodb.py
@@ -183,24 +183,13 @@ class GeoDBClientTest(unittest.TestCase):
 
     def test_get_collection_bbox(self, m):
         self.set_global_mocks(m)
-        expected_bbox = POLYGON
-        url = f"{self._server_test_url}:{self._server_test_port}/rpc/geodb_get_bbox"
-        m.get(url, text=json.dumps(collection))
+        expected_bbox = 'POLYGON ((9 51, 9 53, 11 53, 11 51, 9 51))'
+        url = f"{self._server_test_url}:" \
+              f"{self._server_test_port}/rpc/geodb_get_collection_bbox"
+        m.post(url, text=expected_bbox)
 
-        r = self._api.get_collection('test')
-        self.assertIsInstance(r, GeoDataFrame)
-        self.assertTrue('geometry' in r)
-
-        r = self._api.head_collection('test')
-        self.assertIsInstance(r, GeoDataFrame)
-        self.assertTrue('geometry' in r)
-        self.assertEqual(10, r.shape[0])
-
-        url = f"{self._server_test_url}:{self._server_test_port}/helge_test"
-        m.get(url, json=[])
-        r = self._api.get_collection('test')
-        self.assertIsInstance(r, DataFrame)
-        self.assertEqual(len(r), 0)
+        r = self._api.get_collection_bbox('any')
+        self.assertEqual(expected_bbox, r)
 
     def test_rename_collection(self, m):
         self.set_global_mocks(m)

--- a/tests/core/test_geodb.py
+++ b/tests/core/test_geodb.py
@@ -181,6 +181,27 @@ class GeoDBClientTest(unittest.TestCase):
         self.assertIsInstance(r, DataFrame)
         self.assertEqual(len(r), 0)
 
+    def test_get_collection_bbox(self, m):
+        self.set_global_mocks(m)
+        expected_bbox = POLYGON
+        url = f"{self._server_test_url}:{self._server_test_port}/rpc/geodb_get_bbox"
+        m.get(url, text=json.dumps(collection))
+
+        r = self._api.get_collection('test')
+        self.assertIsInstance(r, GeoDataFrame)
+        self.assertTrue('geometry' in r)
+
+        r = self._api.head_collection('test')
+        self.assertIsInstance(r, GeoDataFrame)
+        self.assertTrue('geometry' in r)
+        self.assertEqual(10, r.shape[0])
+
+        url = f"{self._server_test_url}:{self._server_test_port}/helge_test"
+        m.get(url, json=[])
+        r = self._api.get_collection('test')
+        self.assertIsInstance(r, DataFrame)
+        self.assertEqual(len(r), 0)
+
     def test_rename_collection(self, m):
         self.set_global_mocks(m)
 

--- a/tests/sql/setup.sql
+++ b/tests/sql/setup.sql
@@ -20,12 +20,26 @@ CREATE ROLE "geodb_user" WITH
 GRANT "geodb_user" TO postgres;
 GRANT "geodb_user" TO authenticator;
 
+CREATE ROLE "geodb_user-with-hyphens" WITH
+    LOGIN
+    NOSUPERUSER
+    INHERIT
+    NOCREATEDB
+    NOCREATEROLE
+    NOREPLICATION;
+
+GRANT "geodb_user-with-hyphens" TO postgres;
+GRANT "geodb_user-with-hyphens" TO authenticator;
+
 
 
 GRANT INSERT, SELECT, UPDATE, DELETE ON TABLE public.geodb_user_databases TO "geodb_user";
+GRANT INSERT, SELECT, UPDATE, DELETE ON TABLE public.geodb_user_databases TO "geodb_user-with-hyphens";
 GRANT SELECT, UPDATE, USAGE ON SEQUENCE public.geodb_user_databases_seq TO "geodb_user";
+GRANT SELECT, UPDATE, USAGE ON SEQUENCE public.geodb_user_databases_seq TO "geodb_user-with-hyphens";
 
 INSERT INTO public.geodb_user_databases("name", "owner", "iss") VALUES('geodb_user', 'geodb_user', '');
+INSERT INTO public.geodb_user_databases("name", "owner", "iss") VALUES('geodb_user-with-hyphens', 'geodb_user-with-hyphens', '');
 INSERT INTO public.geodb_user_databases("name", "owner", "iss") VALUES('postgres', 'postgres', '');
 
 CREATE TABLE public.postgres_land_use

--- a/tests/sql/test_sql_functions.py
+++ b/tests/sql/test_sql_functions.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import unittest
 import json
 import psycopg2

--- a/tests/sql/test_sql_functions.py
+++ b/tests/sql/test_sql_functions.py
@@ -244,7 +244,7 @@ class GeoDBSqlTest(unittest.TestCase):
         self.assertIn('geodb_user has not access to that table or database. ', str(e.exception))
 
     def test_get_collection_bbox(self):
-        user_name = "geodb_user"
+        user_name = "geodb_user-with-hyphens"
         user_table = user_name + "_test"
         self._set_role(user_name)
 
@@ -253,10 +253,10 @@ class GeoDBSqlTest(unittest.TestCase):
               f"'{json.dumps(props)}', '4326')"
         self._cursor.execute(sql)
 
-        sql = f"INSERT INTO {user_table} (id, geometry) " \
+        sql = f"INSERT INTO \"{user_table}\" (id, geometry) " \
               "VALUES (1, 'POLYGON((-5 10, -5 11, 5 11, 5 10, -5 10))');"
         self._cursor.execute(sql)
-        sql = f"INSERT INTO {user_table} (id, geometry) " \
+        sql = f"INSERT INTO \"{user_table}\" (id, geometry) " \
               "VALUES (2, 'POLYGON((-6 9, -6 10, 3 10, 3 9, -6 9))');"
         self._cursor.execute(sql)
 

--- a/tests/sql/test_sql_functions.py
+++ b/tests/sql/test_sql_functions.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import unittest
 import json
 import psycopg2
@@ -243,17 +244,39 @@ class GeoDBSqlTest(unittest.TestCase):
 
         self.assertIn('geodb_user has not access to that table or database. ', str(e.exception))
 
+    def test_get_collection_bbox(self):
+        user_name = "geodb_user"
+        user_table = user_name + "_test"
+        self._set_role(user_name)
+
+        props = {}
+        sql = f"SELECT geodb_create_collection('{user_table}', " \
+              f"'{json.dumps(props)}', '4326')"
+        self._cursor.execute(sql)
+
+        sql = f"INSERT INTO {user_table} (id, geometry) " \
+              "VALUES (1, 'POLYGON((-5 10, -5 11, 5 11, 5 10, -5 10))');"
+        self._cursor.execute(sql)
+        sql = f"INSERT INTO {user_table} (id, geometry) " \
+              "VALUES (2, 'POLYGON((-6 9, -6 10, 3 10, 3 9, -6 9))');"
+        self._cursor.execute(sql)
+
+        sql = f"SELECT geodb_get_collection_bbox('{user_table}')"
+        self._cursor.execute(sql)
+        res = self._cursor.fetchone()
+        self.assertEqual('BOX(-6 9,5 11)', res[0])
+
     # noinspection SpellCheckingInspection
     def test_issue_35_unpublish(self):
         user_name = "geodb_user"
         self._set_role(user_name)
 
-        sql = "SELECT geodb_grant_access_to_collection('geodb_user_land_use'," \
-              "'public')"
+        sql = "SELECT geodb_grant_access_to_collection(" \
+              "'geodb_user_land_use', 'public')"
         self._cursor.execute(sql)
 
-        sql = "SELECT geodb_revoke_access_from_collection('geodb_user_land_use'," \
-              "'public')"
+        sql = "SELECT geodb_revoke_access_from_collection( " \
+              "'geodb_user_land_use', 'public')"
         self._cursor.execute(sql)
 
         self._test_publish_unpublish('alllowercase')

--- a/xcube_geodb/core/geodb.py
+++ b/xcube_geodb/core/geodb.py
@@ -273,21 +273,25 @@ class GeoDBClient(object):
             current database
 
         Returns:
-            the bounding box given as [xmin, ymin, xmax, ymax]
+            the bounding box given as tuple xmin, ymin, xmax, ymax
 
         Examples:
             >>> geodb = GeoDBClient(auth_mode='client-credentials', client_id='***', client_secret='***')
             >>> geodb.get_collection_bbox('my_collection')
-            [-5, 10, 5, 11]
+            (-5, 10, 5, 11)
 
         """
         try:
+            from ast import literal_eval
             database = database or self.database
             dn = f"{database}_{collection}"
 
             r = self._post(path='/rpc/geodb_get_collection_bbox', payload={
                 'collection': dn})
-            return r.text
+            bbox = literal_eval(r.json()[0]['geodb_get_collection_bbox']
+                                .replace('BOX', '').replace(' ', ','))
+            result = (bbox[1], bbox[0], bbox[3], bbox[2])
+            return result
         except GeoDBError as e:
             self._maybe_raise(e)
 
@@ -1346,7 +1350,7 @@ class GeoDBClient(object):
         This function can be used to reproject bboxes particularly with the use of GeoDBClient.get_collection_by_bbox.
 
         Args:
-            bbox: Tuple[float, float, float, float]: bbox to be reprojected
+            bbox: Tuple[float, float, float, float]: bbox to be reprojected, given as MINX, MINY, MAXX, MAXY
             from_crs: Source crs e.g. 3974
             to_crs: Target crs e.g. 4326
             wsg84_order (str): WSG84 (EPSG:4326) is expected to be in Lat Lon format ("lat_lon"). Use "lon_lat" if

--- a/xcube_geodb/core/geodb.py
+++ b/xcube_geodb/core/geodb.py
@@ -223,7 +223,8 @@ class GeoDBClient(object):
 
         Args:
             collection (str): The name of the collection to inspect
-            database (str): The database the database resides in [current database]
+            database (str): The database the collection resides in [current
+            database]
 
         Returns:
             A dictionary with collection information
@@ -258,6 +259,37 @@ class GeoDBClient(object):
             return capabilities['definitions'][collection]
         else:
             self._maybe_raise(GeoDBError(f"Table {collection} does not exist."))
+
+    def get_collection_bbox(self, collection: str,
+                            database: Optional[str] = None) -> Sequence:
+        """
+        Retrieves the bounding box for the collection, i.e. the union of all
+        rows' geometries.
+
+        Args:
+            collection (str): The name of the collection to return the
+            bounding box for.
+            database (str): The database the collection resides in. Default:
+            current database
+
+        Returns:
+            the bounding box given as [xmin, ymin, xmax, ymax]
+
+        Examples:
+            >>> geodb = GeoDBClient(auth_mode='client-credentials', client_id='***', client_secret='***')
+            >>> geodb.get_collection_bbox('my_collection')
+            [-5, 10, 5, 11]
+
+        """
+        try:
+            database = database or self.database
+            dn = f"{database}_{collection}"
+
+            r = self._post(path='/rpc/geodb_get_collection_bbox', payload={
+                'collection': dn})
+            return r.text
+        except GeoDBError as e:
+            self._maybe_raise(e)
 
     def get_my_collections(self, database: Optional[str] = None) -> Sequence:
         """

--- a/xcube_geodb/core/geodb.py
+++ b/xcube_geodb/core/geodb.py
@@ -270,7 +270,7 @@ class GeoDBClient(object):
             collection (str): The name of the collection to return the
             bounding box for.
             database (str): The database the collection resides in. Default:
-            current database
+            current database.
 
         Returns:
             the bounding box given as tuple xmin, ymin, xmax, ymax

--- a/xcube_geodb/sql/geodb.sql
+++ b/xcube_geodb/sql/geodb.sql
@@ -378,6 +378,23 @@ BEGIN
 END
 $BODY$;
 
+CREATE OR REPLACE FUNCTION public.geodb_get_collection_bbox(collection text)
+    RETURNS text
+    LANGUAGE 'plpgsql'
+AS
+$BODY$
+DECLARE
+    qry TEXT;
+    bbox TEXT;
+BEGIN
+    qry := format('SELECT text(ST_Extent(geometry)) from ' ||
+           '%s AS ' ||
+           'src', collection);
+    EXECUTE qry INTO bbox;
+
+    RETURN bbox;
+END
+$BODY$;
 
 CREATE OR REPLACE FUNCTION public.geodb_get_my_collections(
     database text DEFAULT NULL::text)

--- a/xcube_geodb/sql/geodb.sql
+++ b/xcube_geodb/sql/geodb.sql
@@ -387,7 +387,7 @@ DECLARE
     qry TEXT;
     bbox TEXT;
 BEGIN
-    qry := format('SELECT text(ST_Extent(geometry)) from "%s" AS src',
+    qry := format('SELECT text(ST_Extent(geometry)) from %I AS src',
                   collection);
     EXECUTE qry INTO bbox;
 

--- a/xcube_geodb/sql/geodb.sql
+++ b/xcube_geodb/sql/geodb.sql
@@ -387,7 +387,7 @@ DECLARE
     qry TEXT;
     bbox TEXT;
 BEGIN
-    qry := format('SELECT text(ST_Extent(geometry)) from %s AS src',
+    qry := format('SELECT text(ST_Extent(geometry)) from "%s" AS src',
                   collection);
     EXECUTE qry INTO bbox;
 

--- a/xcube_geodb/sql/geodb.sql
+++ b/xcube_geodb/sql/geodb.sql
@@ -387,9 +387,8 @@ DECLARE
     qry TEXT;
     bbox TEXT;
 BEGIN
-    qry := format('SELECT text(ST_Extent(geometry)) from ' ||
-           '%s AS ' ||
-           'src', collection);
+    qry := format('SELECT text(ST_Extent(geometry)) from %s AS src',
+                  collection);
     EXECUTE qry INTO bbox;
 
     RETURN bbox;


### PR DESCRIPTION
After merging this PR, there will be a new function in the geoDB: `get_collection_bbox`, that returns the bounding box of all geometries within a collection.

Checklist:

- [x]  Add unit tests and/or doctests in docstrings
- [x]  Changes documented in CHANGES.md
- [x]  CI passes
- [x]  Test coverage remains or increases (target 100%)