### PR TITLE
fixing get_collection_bbox

### DIFF
--- a/tests/core/test_geodb.py
+++ b/tests/core/test_geodb.py
@@ -217,6 +217,13 @@ class GeoDBClientTest(unittest.TestCase):
         bbox = json.dumps(self._api.get_collection_bbox('any'))
         self.assertEqual(str([9, -6, 11, 5]), str(bbox))
 
+        m.post(url, text='[{"geodb_get_collection_bbox":'
+                         '"BOX(112561.21 278713.135,685425.116 570140.955)"}]')
+        bbox = json.dumps(self._api.get_collection_bbox('any'))
+        self.assertEqual(str([278713.135, 112561.21, 570140.955, 685425.116]),
+                         str(bbox))
+
+
     def test_rename_collection(self, m):
         self.set_global_mocks(m)
 

--- a/xcube_geodb/core/geodb.py
+++ b/xcube_geodb/core/geodb.py
@@ -304,9 +304,17 @@ class GeoDBClient(object):
             database = database or self.database
             dn = f"{database}_{collection}"
 
-            r = self._post(path='/rpc/geodb_get_collection_bbox', payload={'collection': dn})
-            bbox = r.json()
-            bbox = literal_eval(bbox.replace('BOX', '').replace(' ', ','))
+            r = self._post(path='/rpc/geodb_get_collection_bbox',
+                           payload={'collection': dn})
+            bbox = r.text \
+                .replace('BOX', '') \
+                .replace(' ', ',') \
+                .replace('[', '').replace(']', '') \
+                .replace('{', '').replace('}', '') \
+                .replace('(', '').replace(')', '') \
+                .replace('"geodb_get_collection_bbox":', '') \
+                .replace('"', '')
+            bbox = literal_eval(bbox)
             return bbox[1], bbox[0], bbox[3], bbox[2]
         except GeoDBError as e:
             self._maybe_raise(e)


### PR DESCRIPTION
Fixing issue #52, by simply adding some string replacement when an unexpected string is returned.
This is not the optimal solution - optimal would be to figure out why PostGRES behaves in the way documented in the issue, and change the behavior if possible.