### PR TITLE
Adapt workflow to GH app

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -209,7 +209,7 @@ jobs:
           if [[ "$HASH" == *"sha256"* ]]; then
             echo ::set-output name=hash::$HASH
           else
-            echo "No has present. Using none as hash. This will use the version tag instead for deployment."
+            echo "No hash present. Using none as hash. This will use the version tag instead for deployment."
             echo ::set-output name=hash::none
           fi
       - name: info
@@ -238,14 +238,21 @@ jobs:
 #          head values-prod.yaml
       - name: Pushes to another repository
         # Don't run if run locally and should be ignored
-        if: ${{ steps.deployment-phase.outputs.phase != 'ignore' && !env.ACT }}
-        uses: cpina/github-action-push-to-another-repository@main
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
-        with:
-          source-directory: 'k8s'
-          destination-github-username: 'bc-org'
-          destination-repository-name: 'k8s-configs'
-          user-email: bcdev@brockmann-consult.de
-          target-branch: main
-          commit-message: ${{ github.event.release }}. Set version to ${{ steps.release.outputs.tag }}
+#        if: ${{ steps.deployment-phase.outputs.phase != 'ignore' && !env.ACT }}
+        run: |
+          cd ./k8s/k8s-configs
+          echo "deleteme" >> xcube-geodb/test.txt
+          git add xcube-geodb/test.txt
+          git commit -m "test"
+          git remote set-url origin https://x-access-token:${{ steps.get_installation_token.outputs.token }}@github.com/bc-org/k8s-configs.git
+          git push origin main
+#        uses: cpina/github-action-push-to-another-repository@main
+#        env:
+#          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+#        with:
+#          source-directory: 'k8s'
+#          destination-github-username: 'bc-org'
+#          destination-repository-name: 'k8s-configs'
+#          user-email: bcdev@brockmann-consult.de
+#          target-branch: main
+#          commit-message: ${{ github.event.release }}. Set version to ${{ steps.release.outputs.tag }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -175,16 +175,22 @@ jobs:
           app_id: ${{ secrets.XCUBE_GEODB_GH_ID }}
           private_key: ${{ secrets.PRIVATE_KEY_XCUBE_GEODB_APP }}
           repository: bc-org/k8s-configs
+          # the installationId of the GitHub app we are using
           installationId: 36950178
       - name: git-checkout
         uses: actions/checkout@v2
       # Clone k8s-config into path 'k8s'
-      - uses: actions/checkout@v2
-        with:
-          repository: bc-org/k8s-configs
-          token: ${{ steps.get_installation_token.outputs.token }}
-          ref: main
-          path: k8s
+#      - uses: actions/checkout@v2
+#        with:
+#          repository: bc-org/k8s-configs
+#          token: ${{ steps.get_installation_token.outputs.token }}
+#          ref: main
+#          path: k8s
+      - name: checkout-k8s
+        run: |
+          mkdir k8s
+          cd k8s
+          git clone https://x-access-token:${{ steps.get_installation_token.outputs.token }}@github.com/bc-org/k8s-configs.git
       # Get the release tag (or main on push)
       - name: get-release-tag
         id: release

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -228,9 +228,9 @@ jobs:
           delimiter: ' '
           tag: ${{ steps.deployment-phase.outputs.tag }}
           hash: ${{ steps.get-hash.outputs.hash }}
-          working-directory: "./k8s/${{ env.APP_NAME }}-jh/helm"
+          working-directory: "./k8s/k8s-configs/${{ env.APP_NAME }}-jh/helm"
       - name: cat-result
-        working-directory: "./k8s/${{ env.APP_NAME }}-jh/helm"
+        working-directory: "./k8s/k8s-configs/${{ env.APP_NAME }}-jh/helm"
         run: |
           head values-dev.yaml
           head values-stage.yaml

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -171,8 +171,8 @@ jobs:
         id: get_installation_token
         uses: tibdex/github-app-token@v1
         with:
-          app_id: ${{ secrets.XCUBE_GEODB_GH_ID }}
-          private_key: ${{ secrets.PRIVATE_KEY_XCUBE_GEODB_APP }}
+          app_id: ${{ secrets.TOKEN_PROVIDER_APP_ID }}
+          private_key: ${{ secrets.TOKEN_PROVIDER_KEY }}
           repository: bc-org/k8s-configs
           # the installationId of the GitHub app we are using
           installationId: 36950178

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -241,6 +241,7 @@ jobs:
 #        if: ${{ steps.deployment-phase.outputs.phase != 'ignore' && !env.ACT }}
         run: |
           cd ./k8s/k8s-configs
+          git config user.name "$GITHUB_ACTOR"
           echo "deleteme" >> xcube-geodb/test.txt
           git add xcube-geodb/test.txt
           git commit -m "test"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -17,8 +17,8 @@ env:
   # When developing jobs it could make sense to switch off the test sections as they take time
   # Unfortunately, you cannot set an if statement on job level. Hence, these variables are used in each step
   # of a unittest/nb-test job.
-  RUN_UNITTESTS: "0"
-  RUN_NB_TESTS: "0"
+  RUN_UNITTESTS: "1"
+  RUN_NB_TESTS: "1"
 
   # Determines whether the dev branch ouy are working on shall have a docker image (default 0)
   DOCKER_BUILD_MY_BRANCH: "0"
@@ -137,8 +137,7 @@ jobs:
       - uses: mr-smithers-excellent/docker-build-push@v5.5
         name: build-push-docker-image-latest
         # Build the image only for dev/stage/prod phases or if DOCKER_BUILD_MY_BRANCH is set to '1'
-        if: ${{ env.DOCKER_BUILD_MY_BRANCH == '1' }}
-#        if: ${{ steps.deployment-phase.outputs.phase != 'ignore' || env.DOCKER_BUILD_MY_BRANCH == '1' }}
+        if: ${{ steps.deployment-phase.outputs.phase != 'ignore' || env.DOCKER_BUILD_MY_BRANCH == '1' }}
         with:
           image: ${{ env.ORG_NAME }}/${{ env.APP_NAME }}-lab
           # Adds 'latest' tag when main is built (see: https://github.com/mr-smithers-excellent/docker-build-push#tagging-the-image-using-gitops)
@@ -150,7 +149,7 @@ jobs:
       # Build PostGIS docker image
       - uses: mr-smithers-excellent/docker-build-push@v5.5
         name: build-push-docker-backend-image-latest
-        if: ${{ env.DOCKER_BUILD_MY_BRANCH == '1' }}
+        if: ${{ steps.deployment-phase.outputs.phase != 'ignore'  || env.DOCKER_BUILD_MY_BRANCH == '1' }}
         with:
           image: ${{ env.ORG_NAME }}/${{ env.APP_NAME }}-backend
           directory: xcube_geodb/sql
@@ -165,7 +164,7 @@ jobs:
     env:
       PUSH: 1
     runs-on: ubuntu-latest
-#    needs: build-docker-image
+    needs: build-docker-image
     name: update-tag
     steps:
       - name: Get installation token
@@ -180,12 +179,6 @@ jobs:
       - name: git-checkout
         uses: actions/checkout@v2
       # Clone k8s-config into path 'k8s'
-#      - uses: actions/checkout@v2
-#        with:
-#          repository: bc-org/k8s-configs
-#          token: ${{ steps.get_installation_token.outputs.token }}
-#          ref: main
-#          path: k8s
       - name: checkout-k8s
         run: |
           mkdir k8s
@@ -238,22 +231,11 @@ jobs:
 #          head values-prod.yaml
       - name: Pushes to another repository
         # Don't run if run locally and should be ignored
-#        if: ${{ steps.deployment-phase.outputs.phase != 'ignore' && !env.ACT }}
+        if: ${{ steps.deployment-phase.outputs.phase != 'ignore' && !env.ACT }}
         run: |
           cd ./k8s/k8s-configs
-          git config user.name "$GITHUB_ACTOR"
-          echo "deleteme" >> xcube-geodb/test.txt
-          git add xcube-geodb/test.txt
-          git commit -m "test"
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git commit -m "${{ github.event.release }}. Set version to ${{ steps.release.outputs.tag }}"
           git remote set-url origin https://x-access-token:${{ steps.get_installation_token.outputs.token }}@github.com/bc-org/k8s-configs.git
           git push origin main
-#        uses: cpina/github-action-push-to-another-repository@main
-#        env:
-#          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
-#        with:
-#          source-directory: 'k8s'
-#          destination-github-username: 'bc-org'
-#          destination-repository-name: 'k8s-configs'
-#          user-email: bcdev@brockmann-consult.de
-#          target-branch: main
-#          commit-message: ${{ github.event.release }}. Set version to ${{ steps.release.outputs.tag }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -168,8 +168,8 @@ jobs:
 #    needs: build-docker-image
     name: update-tag
     steps:
-      - name: Generate token
-        id: generate_token
+      - name: Get installation token
+        id: get_installation_token
         uses: tibdex/github-app-token@v1
         with:
           app_id: ${{ secrets.XCUBE_GEODB_GH_ID }}
@@ -182,7 +182,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: bc-org/k8s-configs
-          token: ${{ steps.generate_token.outputs.token }}
+          token: ${{ steps.get_installation_token.outputs.token }}
           ref: main
           path: k8s
       # Get the release tag (or main on push)


### PR DESCRIPTION
This PR adapts authentication within the GH workflow to use the dedicated GH app instead of relying on a PAT. See https://github.com/bc-org/best-practices-devops/pull/14.

Checklist:

* [ ] Added unit tests and/or doctests in docstrings - irrelevant, is tested by CI
* [ ] Added docstrings and API docs for any new/modified user-facing classes and functions - irrelevant
* [ ] New/modified features documented in `docs/source/*` - irrelevant 
* [ ] Changes documented in `CHANGES.md` - irrelevant because internal
* [x] GitHub CI passes
* [x] Test coverage remains or increases (target 100%)