### PR TITLE
Allow users to retrieve geometry types

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,6 @@
 Checklist:
 
 * [ ] Issue has been created for change
-* [ ] Added unit tests and/or doctests in docstrings
 * [ ] Added docstrings and API docs for any new/modified user-facing classes and functions
 * [ ] New/modified features documented in `docs/source/*`
 * [ ] Changes documented in `CHANGES.md`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ### New Features
 
+- added function that allows users to retrieve the geometry types from their 
+  collections
+
 ### Fixes
 
 ## v1.0.6

--- a/tests/core/test_geodb.py
+++ b/tests/core/test_geodb.py
@@ -236,9 +236,9 @@ class GeoDBClientTest(unittest.TestCase):
         self.set_global_mocks(m)
 
         url = f"{self._base_url}/rpc/geodb_geometry_types"
-        m.post(url, json={'types': [{'geometrytype': 'POLYGON'},
+        m.post(url, json=[{'types': [{'geometrytype': 'POLYGON'},
                                     {'geometrytype': 'POLYGON'},
-                                    {'geometrytype': 'POINT'}]})
+                                    {'geometrytype': 'POINT'}]}])
 
         res = self._api.get_geometry_types('test', aggregate=False,
                                            database='test_db')
@@ -246,8 +246,8 @@ class GeoDBClientTest(unittest.TestCase):
         self.assertListEqual(res, expected)
 
         url = f"{self._base_url}/rpc/geodb_geometry_types"
-        m.post(url, json={'types': [{'geometrytype': 'POINT'},
-                                    {'geometrytype': 'POLYGON'}]})
+        m.post(url, json=[{'types': [{'geometrytype': 'POINT'},
+                                    {'geometrytype': 'POLYGON'}]}])
 
         res = self._api.get_geometry_types('test', aggregate=True,
                                            database='test_db')

--- a/tests/core/test_geodb.py
+++ b/tests/core/test_geodb.py
@@ -232,6 +232,28 @@ class GeoDBClientTest(unittest.TestCase):
         bbox = self._api.get_collection_bbox('any')
         self.assertIsNone(bbox)
 
+    def test_get_geometry_types(self, m):
+        self.set_global_mocks(m)
+
+        url = f"{self._base_url}/rpc/geodb_geometry_types"
+        m.post(url, json={'types': [{'geometrytype': 'POLYGON'},
+                                    {'geometrytype': 'POLYGON'},
+                                    {'geometrytype': 'POINT'}]})
+
+        res = self._api.get_geometry_types('test', aggregate=False,
+                                           database='test_db')
+        expected = ['POLYGON', 'POLYGON', 'POINT']
+        self.assertListEqual(res, expected)
+
+        url = f"{self._base_url}/rpc/geodb_geometry_types"
+        m.post(url, json={'types': [{'geometrytype': 'POINT'},
+                                    {'geometrytype': 'POLYGON'}]})
+
+        res = self._api.get_geometry_types('test', aggregate=True,
+                                           database='test_db')
+        expected = ['POINT', 'POLYGON']
+        self.assertListEqual(res, expected)
+
     def test_rename_collection(self, m):
         self.set_global_mocks(m)
 

--- a/tests/sql/test_sql_functions.py
+++ b/tests/sql/test_sql_functions.py
@@ -376,6 +376,39 @@ class GeoDBSqlTest(unittest.TestCase):
         res = self._cursor.fetchone()
         self.assertEqual('BOX(-6 9,5 11)', res[0])
 
+    def test_get_geometry_types(self):
+        user_name = "geodb_user"
+        self._set_role(user_name)
+        user_table = user_name + "_test"
+
+        props = {}
+        sql = f"SELECT geodb_create_collection('{user_table}', " \
+              f"'{json.dumps(props)}', '4326')"
+        self._cursor.execute(sql)
+
+        sql = f"INSERT INTO \"{user_table}\" (id, geometry) " \
+              "VALUES (1, 'POLYGON((-5 10, -5 11, 5 11, 5 10, -5 10))');"
+        self._cursor.execute(sql)
+        sql = f"INSERT INTO \"{user_table}\" (id, geometry) " \
+              "VALUES (2, 'POLYGON((-6 9, -6 10, 3 10, 3 9, -6 9))');"
+        self._cursor.execute(sql)
+        sql = f"INSERT INTO \"{user_table}\" (id, geometry) " \
+              "VALUES (3, 'POINT(-6 9)');"
+        self._cursor.execute(sql)
+
+        sql = f"SELECT geodb_geometry_types('{user_table}', 'false')"
+        self._cursor.execute(sql)
+        res = self._cursor.fetchone()
+        self.assertListEqual([{'geometrytype': 'POLYGON'},
+                              {'geometrytype': 'POLYGON'},
+                              {'geometrytype': 'POINT'}], res[0])
+
+        sql = f"SELECT geodb_geometry_types('{user_table}', 'true')"
+        self._cursor.execute(sql)
+        res = self._cursor.fetchone()
+        self.assertListEqual([{'geometrytype': 'POINT'},
+                              {'geometrytype': 'POLYGON'}], res[0])
+
     def test_estimate_collection_bbox(self):
         user_name = "geodb_user-with-hyphens"
         user_table = user_name + "_test"

--- a/xcube_geodb/core/geodb.py
+++ b/xcube_geodb/core/geodb.py
@@ -362,7 +362,7 @@ class GeoDBClient(object):
             payload = {'collection': dn,
                        'aggregate': 'true' if aggregate else 'false'}
             r = self._post(path='/rpc/geodb_geometry_types', payload=payload)
-            types = r.json()['types']
+            types = r.json()[0]['types']
             return [a['geometrytype'] for a in types]
         except GeoDBError as e:
             self._maybe_raise(e)

--- a/xcube_geodb/core/geodb.py
+++ b/xcube_geodb/core/geodb.py
@@ -337,6 +337,36 @@ class GeoDBClient(object):
         except GeoDBError as e:
             self._maybe_raise(e)
 
+    def get_geometry_types(self, collection: str, aggregate: bool = True,
+                           database: Optional[str] = None) -> List[str]:
+        """
+        Retrieves the geometry types of the given collection, either as an
+        extensive list of the geometry types for each collection entry, or
+        as aggregated list of the types that appear in the collection.
+
+        Args:
+            collection (str):  The collection to list geometry types for
+            aggregate (bool):  If the result shall be an aggregated list
+            database (str):    The database that contains the collection
+        Returns:
+            List[str]: A list of the geometry types, either for each
+                       collection entry or aggregated.
+        Raises:
+            GeoDBError: If the database raises an error
+        """
+
+        try:
+            database = database or self._database
+            dn = f"{database}_{collection}"
+
+            payload = {'collection': dn,
+                       'aggregate': 'true' if aggregate else 'false'}
+            r = self._post(path='/rpc/geodb_geometry_types', payload=payload)
+            types = r.json()['types']
+            return [a['geometrytype'] for a in types]
+        except GeoDBError as e:
+            self._maybe_raise(e)
+
     def get_my_collections(self, database: Optional[str] = None) -> Sequence:
         """
 

--- a/xcube_geodb/core/geodb.py
+++ b/xcube_geodb/core/geodb.py
@@ -346,7 +346,7 @@ class GeoDBClient(object):
 
         Args:
             collection (str):  The collection to list geometry types for
-            aggregate (bool):  If the result shall be an aggregated list
+            aggregate (bool):  If the result shall be an aggregated list, default is set to "True"
             database (str):    The database that contains the collection
         Returns:
             List[str]: A list of the geometry types, either for each

--- a/xcube_geodb/core/geodb.py
+++ b/xcube_geodb/core/geodb.py
@@ -360,7 +360,7 @@ class GeoDBClient(object):
             dn = f"{database}_{collection}"
 
             payload = {'collection': dn,
-                       'aggregate': 'true' if aggregate else 'false'}
+                       'aggregate': 'TRUE' if aggregate else 'FALSE'}
             r = self._post(path='/rpc/geodb_geometry_types', payload=payload)
             types = r.json()[0]['types']
             return [a['geometrytype'] for a in types]

--- a/xcube_geodb/sql/geodb.sql
+++ b/xcube_geodb/sql/geodb.sql
@@ -465,6 +465,30 @@ BEGIN
 END
 $BODY$;
 
+CREATE OR REPLACE FUNCTION public.geodb_geometry_types(collection text, aggregate boolean DEFAULT true)
+    RETURNS TABLE
+        (
+            types json
+        )
+    LANGUAGE 'plpgsql'
+AS
+$BODY$
+DECLARE
+    qry TEXT;
+BEGIN
+    IF aggregate THEN
+        qry := format('SELECT JSON_AGG(temp) AS types FROM (
+                        SELECT DISTINCT GeometryType(geometry) FROM %I) AS temp',
+                        collection);
+    ELSE
+        qry := format('SELECT JSON_AGG(temp) AS types FROM (
+                        SELECT GeometryType(geometry) FROM %I) AS temp',
+                        collection);
+    END IF;
+    RETURN QUERY EXECUTE qry;
+END
+$BODY$;
+
 CREATE OR REPLACE FUNCTION public.geodb_get_my_collections(
     database text DEFAULT NULL::text)
     RETURNS TABLE


### PR DESCRIPTION
After acceptance of this PR, it will be possible to quickly retrieve the different geometry types for a given collection.

Checklist:

* [x] Issue has been created for change
* [x] Added docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in `docs/source/*`
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [ ] Test coverage remains or increases (target 100%)